### PR TITLE
Add meeting agenda for future meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ an agenda item*.
 All meetings occur via video conference, however participating company
 offices are welcome to host guests.
 
-Meetings are typically scheduled for the last Wednesday of each month at 4:00pm
+Meetings are typically scheduled for the last Wednesday of each month at 5:00pm
 UTC. Check the [`agendas/`](./agendas) for the exact date and time
 of upcoming meetings.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Meetings are typically scheduled for the last Wednesday of each month at 4:00pm
 UTC. Check the [`agendas/`](./agendas) for the exact date and time
 of upcoming meetings.
 
+<!-- These are broken. Need to fix them see https://github.com/graphql/graphql-js-wg/issues/24
 Keep track of future upcoming meetings by subscribing to the
-[Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). (maintained in UTC because time zones are hard).
+[Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). (maintained in UTC because time zones are hard). 
+-->
 
 ### Joining a meeting?
 

--- a/agendas/2020-12-23.md
+++ b/agendas/2020-12-23.md
@@ -1,0 +1,11 @@
+# GraphQL-JS WG – December 2020
+
+### This call was moved to [January 05 2021](./2021-01-05.md) as discussed in [graphql-js-wg#20](https://github.com/graphql/graphql-js-wg/issues/20)
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [December 23 2021 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=12&day=23&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+

--- a/agendas/2021-01-05.md
+++ b/agendas/2021-01-05.md
@@ -1,4 +1,4 @@
-# GraphQL-JS WG – January 2021
+# GraphQL-JS WG – January 2021 (replacement for December 2020 call)
 
 The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
 relevant topics to core Javascript GraphQL projects. This is an open meeting in which

--- a/agendas/2021-01-27.md
+++ b/agendas/2021-01-27.md
@@ -1,0 +1,64 @@
+# GraphQL-JS WG – January 2021
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [January 27 2021 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2021&month=01&day=27&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+<!--
+These links do not show this working group details I think someone needs to set those up. https://github.com/graphql/graphql-js-wg/issues/24
+ view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)). 
+ -->
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
+- **Live Notes**: TBD
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                     | Organization / Project       | Location
+| ------------------------ | ---------------------------- | ------------------------
+| Ivan Goncharov           | GraphQL foundation           | Lviv, Ukraine
+| *ADD YOUR NAME ABOVE TO ATTEND*
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+2. Introduction of attendees (5m, Ivan)
+3. Determine volunteers for note taking (1m, Ivan)
+4. Review agenda (2m, Ivan)
+5. Review previous meeting's action items (5m, Ivan)
+   - [All action items](https://github.com/graphql/graphql-js-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
+9.  _ADD YOUR AGENDA ABOVE_

--- a/agendas/2021-02-24.md
+++ b/agendas/2021-02-24.md
@@ -1,0 +1,64 @@
+# GraphQL-JS WG – February 2021
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & time**: [February 24 2021 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2021&month=02&day=24&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+<!--
+These links do not show this working group details I think someone needs to set those up. https://github.com/graphql/graphql-js-wg/issues/24
+ view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)). 
+ -->
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
+- **Live Notes**: TBD
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                     | Organization / Project       | Location
+| ------------------------ | ---------------------------- | ------------------------
+| Ivan Goncharov           | GraphQL foundation           | Lviv, Ukraine
+| *ADD YOUR NAME ABOVE TO ATTEND*
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+2. Introduction of attendees (5m, Ivan)
+3. Determine volunteers for note taking (1m, Ivan)
+4. Review agenda (2m, Ivan)
+5. Review previous meeting's action items (5m, Ivan)
+   - [All action items](https://github.com/graphql/graphql-js-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
+9.  _ADD YOUR AGENDA ABOVE_

--- a/agendas/2021-03-31.md
+++ b/agendas/2021-03-31.md
@@ -1,0 +1,64 @@
+# GraphQL-JS WG – March 2021
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [March 31 2021 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2021&month=03&day=31&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+<!--
+These links do not show this working group details I think someone needs to set those up. https://github.com/graphql/graphql-js-wg/issues/24
+ view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)). 
+ -->
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
+- **Live Notes**: TBD
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                     | Organization / Project       | Location
+| ------------------------ | ---------------------------- | ------------------------
+| Ivan Goncharov           | GraphQL foundation           | Lviv, Ukraine
+| *ADD YOUR NAME ABOVE TO ATTEND*
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+2. Introduction of attendees (5m, Ivan)
+3. Determine volunteers for note taking (1m, Ivan)
+4. Review agenda (2m, Ivan)
+5. Review previous meeting's action items (5m, Ivan)
+   - [All action items](https://github.com/graphql/graphql-js-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
+9.  _ADD YOUR AGENDA ABOVE_


### PR DESCRIPTION
### Summary
* Remove calendar links temporarily to avoid any confusion see #24 for more details
* Change meeting time to 5:00 PM UTC as discussed in today's call (same time as [`graphql-wg`](https://github.com/graphql/graphql-wg))
* Add a placeholder for December meeting that will redirect to Jan 5 (as meeting was rescheduled in #20) 
* Add templates for Jan, Feb and March meetings.