### PR TITLE
add Feb 2022 agenda

### DIFF
--- a/agendas/2022-02-22.md
+++ b/agendas/2022-02-22.md
@@ -1,0 +1,70 @@
+# GraphQL-JS WG – February 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [February 23 2021 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=02&day=23&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+- **Live Notes**: TBD
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location         |
+| ------------------------------- | ---------------------- | ---------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine    |
+| Saihajpreet Singh               | The Guild              | Ottawa, ON, CA   |
+| *ADD YOUR NAME ABOVE TO ATTEND* |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Determine volunteers for note taking (1m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+    - [Require opt-in to allow `@defer`/`@stream`](https://github.com/robrichard/defer-stream-wg/discussions/12)
+1. Canary Releases [`graphql-js#3383`](https://github.com/graphql/graphql-js/issues/3383)
+   1. Potential concerns with current implementation (5m, Saihaj)
+1. Road to ESM [`graphql-js#3361`](https://github.com/graphql/graphql-js/pull/3361) (10m, Saihaj)
+1. Introspection query type issues [`graphql-js#3409`](https://github.com/graphql/graphql-js/issues/3409)
+1. Inconsistent handling of directives [`graphql-js#3419`](https://github.com/graphql/graphql-js/issues/3419)
+1. Roadmap to `v17`
+1. _ADD YOUR AGENDA ABOVE_


### PR DESCRIPTION
---
name: Meeting Agenda or Attendance
about: Template for adding agenda or attendance to an upcoming GraphQL-JS Working Group meeting.
labels: 'Agenda :hand:'
---

<!--

Before attending a GraphQL Working Group meeting, please check the following:

- You (or your organization) has signed the Specification Membership Agreement.
  https://github.com/graphql/foundation

- You have read the participation guidelines and intend on contributing to the discussion. To respect meeting size, attendees should be relevant to the agenda. Recordings and notes will be posted after the meeting.
  https://github.com/graphql/graphql-js-wg#participation-guidelines

- Agenda items must include:
  - Relevant links (RFC, issues, PRs)
  - Champion's name
  - Expected time to discuss

-->
