### PR TITLE
add agendas for rest of 2022

### DIFF
--- a/agendas/2022/2022-06-29.md
+++ b/agendas/2022/2022-06-29.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – June 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [June 29 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=06&day=29&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_

--- a/agendas/2022/2022-07-27.md
+++ b/agendas/2022/2022-07-27.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – July 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [July 27 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=07&day=27&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_

--- a/agendas/2022/2022-08-31.md
+++ b/agendas/2022/2022-08-31.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – August 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [August 31 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=08&day=31&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_

--- a/agendas/2022/2022-09-28.md
+++ b/agendas/2022/2022-09-28.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – September 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [September 28 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=09&day=28&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_

--- a/agendas/2022/2022-10-26.md
+++ b/agendas/2022/2022-10-26.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – October 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [October 26 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=10&day=26&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_

--- a/agendas/2022/2022-11-30.md
+++ b/agendas/2022/2022-11-30.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – November 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [November 30 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=11&day=30&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_

--- a/agendas/2022/2022-12-28.md
+++ b/agendas/2022/2022-12-28.md
@@ -1,0 +1,60 @@
+# GraphQL-JS WG – December 2022
+
+The GraphQL Working Group meets monthly to discuss proposed changes to the [GraphQL-JS](https://github.com/graphql/graphql-spec) library, other related foundation libraries like [express-graphql](https://github.com/graphql/express-graphql) and [graphql-relay-js](https://github.com/graphql/graphql-relay-js) and other
+relevant topics to core Javascript GraphQL projects. This is an open meeting in which
+anyone in the GraphQL community may attend. *To attend this meeting or propose
+agenda, edit this file.*
+
+- **Date & Time**: [December 28 2022 17:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=12&day=28&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **Calendar**:
+[Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). Email [operations@graphql.org](mailto:operations@graphql.org) to be added directly to the invite.
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+- **Video Conference Link**: https://zoom.us/j/96871026087
+  - Password: graphqljs
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace ✏)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+>
+> **By joining the meeting you consent to being recorded and agree to the Specification Membership Agreement, participation guidelines, and code of conduct. Meetings may be recorded, by joining you grant permission to be recoded.**
+
+| Name                            | Organization / Project | Location      |
+| ------------------------------- | ---------------------- | ------------- |
+| Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
+
+
+## Agenda
+
+> **Guidelines**
+>
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Ivan)
+    - [Specification Membership Agreement](https://github.com/graphql/foundation)
+    - [Participation Guidelines](https://github.com/graphql/graphql-js-wg#participation-guidelines)
+    - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Ivan)
+1. Review agenda (2m, Ivan)
+1. Review previous meeting's action items (5m, Ivan)
+    - [All action items](https://github.com/graphql/graphql-js-wg/issues)
+1. ADD YOUR ACTION ITEMS ABOVE_


### PR DESCRIPTION
Adds agendas for rest of 2022 in `/agendas/2022` not moving other files to this directory for backwards compat.
