### PR TITLE
Add `execute`/`experimentalExecute` to Sept meeting

### DIFF
--- a/agendas/2022/2022-09-28.md
+++ b/agendas/2022/2022-09-28.md
@@ -27,6 +27,7 @@ agenda, edit this file.*
 | Name                            | Organization / Project | Location      |
 | ------------------------------- | ---------------------- | ------------- |
 | Ivan Goncharov                  | ApolloGraphQL          | Lviv, Ukraine |
+| Yaacov Rydzinski                | Individual             | Neve Daniel, Israel |
 | *ADD YOUR NAME ABOVE TO ATTEND* |                        |               |
 
 
@@ -57,4 +58,7 @@ Example agenda item:
 1. Review agenda (2m, Ivan)
 1. Review previous meeting's action items (5m, Ivan)
     - [All action items](https://github.com/graphql/graphql-js-wg/issues)
-1. ADD YOUR ACTION ITEMS ABOVE_
+1. Incremental Delivery - `execute`/`experimentalExecute`
+    - Discuss: should enabling experimental features that change `execute` return type use (a) experimental functions, (b) experimental options or (c) only the experimental directives?
+    - PRs: [#3722](https://github.com/graphql/graphql-js/pull/3722) [#3726](https://github.com/graphql/graphql-js/pull/3726) [#3727](https://github.com/graphql/graphql-js/pull/3727) [#3732](https://github.com/graphql/graphql-js/pull/3732)
+3. ADD YOUR ACTION ITEMS ABOVE_


### PR DESCRIPTION
1. Incremental Delivery - `execute`/`experimentalExecute`
    - Discuss: should enabling experimental features that change `execute` return type use (a) experimental functions, (b) experimental options or (c) only the experimental directives?
    - PRs: [#3722](https://github.com/graphql/graphql-js/pull/3722) [#3726](https://github.com/graphql/graphql-js/pull/3726) [#3727](https://github.com/graphql/graphql-js/pull/3727) [#3732](https://github.com/graphql/graphql-js/pull/3732)